### PR TITLE
Update HSAttachmentPicker in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "helpscout/HSAttachmentPicker" == 1.0.4
+github "helpscout/HSAttachmentPicker" == 1.0.8

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "helpscout/HSAttachmentPicker" "1.0.4"
+github "helpscout/HSAttachmentPicker" "1.0.8"


### PR DESCRIPTION
Update Carthage dependency [HSAttachmentPicker](https://github.com/helpscout/HSAttachmentPicker) to the latest version (1.0.8).