### PR TITLE
Removes resources from Beacon.podspec to dedup Beacon.bundle

### DIFF
--- a/Beacon.podspec
+++ b/Beacon.podspec
@@ -18,6 +18,5 @@ Pod::Spec.new do |s|
   s.module_map    = 'Beacon.xcframework/ios-arm64/Beacon.framework/Modules/module.modulemap'  
   s.preserve_paths = 'Beacon.xcframework'
   s.vendored_frameworks = 'Beacon.xcframework'
-  s.resources     = 'Beacon.xcframework/ios-arm64/Beacon.framework/Beacon.bundle'
   s.frameworks    = 'UIKit', 'Photos', 'UserNotifications', 'WebKit', 'MobileCoreServices', 'SafariServices', 'QuickLook', 'CoreData'
 end


### PR DESCRIPTION
📌 https://github.com/helpscout/beacon-ios-sdk/issues/149

Because `Beacon.bundle` is included with `Beacon.xcframework` that we vend via `Beacon.podspec` referencing it via the Podspec resource it ends up being present twice in the app, once in the `Beacon.xcframework` and once copied over by Cocoapods.  This fix eliminates the duplication.