### PR TITLE
Add supported platform and language versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Beacon 2.0.x requires Xcode 11.4
 
 ### Supported platform and language versions
 
-* iOS 11.0 to 14.0
-* Swift 5.4
-
+* iOS 11 to 14
+* Swift 5
+* Xcode 12
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The Beacon SDK 2.0 requires iOS 11.0+.
 As of Beacon 2.1.0 Xcode 12 is required to build with the Beacon SDK.
 Beacon 2.0.x requires Xcode 11.4
 
+### Supported platform and language versions
+
+* iOS 11.0 to 14.0
+* Swift 5.4
+
+
 ## Installation
 
 ### CocoaPods


### PR DESCRIPTION
Similar to the Android sample [here](https://github.com/helpscout/beacon-android-sdk-sample/pull/174), we're adding Supported platform and language versions section to the readme. 