### PR TITLE
Updated supported platforms with release of iOS16

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Beacon 2.0.x requires Xcode 11.4
 
 ### Supported platform and language versions
 
-* iOS 14 to 16
+* iOS 11 to 16
 * Swift 5
-* Xcode 12
+* Xcode 12+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Beacon 2.0.x requires Xcode 11.4
 
 ### Supported platform and language versions
 
-* iOS 11 to 14
+* iOS 14 to 16
 * Swift 5
 * Xcode 12
 


### PR DESCRIPTION
As part of our commitment to ensure customers/developers who use the iOS Beacon SDK are aware of our supported platforms I've updated this iOS Supported platform and language versions in line with the newly release iOS 16. 

Internal ticket reference https://helpscout.atlassian.net/browse/MOBILE-1157